### PR TITLE
Replace builtin "store" with Redis integration

### DIFF
--- a/purrr/autokitteh.yaml
+++ b/purrr/autokitteh.yaml
@@ -2,6 +2,7 @@
 # - Modify the values in the "vars" section, if desired
 # - Create AutoKitteh connection tokens for GitHub and Slack,
 #   and replace the "TODO" lines below
+# - Modify the Redis connection string, if needed
 
 version: v1
 
@@ -21,6 +22,9 @@ project:
     - name: github
       integration: github
       token: TODO # Replace this with an AutoKitteh connection token.
+    - name: redis
+      integration: redis
+      token: "redis://localhost:6379/0" # Modify this if needed.
     - name: slack
       integration: slack
       token: TODO # Replace this with an AutoKitteh connection token.

--- a/purrr/github_pr.star
+++ b/purrr/github_pr.star
@@ -3,6 +3,7 @@
 # TODO: Refactor all handlers to mention even if PR channel not found
 # (to print to log channel at least - mention functions already implement this correctly).
 
+load("@redis", "redis")
 load("@slack", "slack")
 load("debug.star", "debug")
 load("env", "REDIS_TTL")  # Set in "autokitteh.yaml".
@@ -110,8 +111,7 @@ def _on_pr_opened(data):
     slack.bookmarks_add(channel_id, title, pr.htmlurl + ".diff")
 
     # Remember the ID of the channel we just created, for other events.
-    # See: https://redis.io/commands/set/
-    resp = store.set(pr.htmlurl, channel_id, REDIS_TTL)
+    resp = redis.set(pr.htmlurl, channel_id, REDIS_TTL)
     if resp != "OK":
         debug('Redis "set %s %s" failed: %s' % (pr.htmlurl, channel_id, resp))
 

--- a/purrr/github_pr.star
+++ b/purrr/github_pr.star
@@ -1,8 +1,5 @@
 """Handler for GitHub "pull_request" events."""
 
-# TODO: Refactor all handlers to mention even if PR channel not found
-# (to print to log channel at least - mention functions already implement this correctly).
-
 load("@redis", "redis")
 load("@slack", "slack")
 load("debug.star", "debug")

--- a/purrr/github_pr_review.star
+++ b/purrr/github_pr_review.star
@@ -1,5 +1,6 @@
 """Handler for GitHub "pull_request_review" events."""
 
+load("@redis", "redis")
 load("debug.star", "debug")
 load("env", "REDIS_TTL")  # Set in "autokitteh.yaml".
 load("markdown.star", "github_markdown_to_slack")
@@ -45,8 +46,7 @@ def _on_pr_review_submitted(data):
 
     # Remember the thread timestamp (message ID) of the message we posted.
     if thread_ts:
-        # See: https://redis.io/commands/set/
-        resp = store.set(data.review.htmlurl, thread_ts, REDIS_TTL)
+        resp = redis.set(data.review.htmlurl, thread_ts, REDIS_TTL)
         if resp != "OK":
             msg = 'Redis "set %s %s" failed: %s'
             debug(msg % (data.review.htmlurl, thread_ts, resp))

--- a/purrr/slack_cmd.star
+++ b/purrr/slack_cmd.star
@@ -1,5 +1,6 @@
 """Handler for Slack slash-command events."""
 
+load("@redis", "redis")
 load("@slack", "slack")
 
 WAKE_WORD = "purrr"
@@ -84,16 +85,14 @@ def _opt_in(data, args):
         _error(data, args[0], "this command doesn't accept extra arguments")
         return
 
-    # See: https://redis.io/commands/get/
     key_prefix = "slack_opt_out:"
-    opt_out = store.get(key_prefix + data.user_id)
+    opt_out = redis.get(key_prefix + data.user_id)
     if not opt_out:
         msg = ":bell: You're already opted into PuRRR"
         slack.chat_post_ephemeral(data.channel_id, data.user_id, msg)
         return
 
-    # See: https://redis.io/commands/del/
-    store.delete(key_prefix + data.user_id)
+    redis.delete(key_prefix + data.user_id)
     msg = ":bell: You are now opted into PuRRR"
     slack.chat_post_ephemeral(data.channel_id, data.user_id, msg)
 
@@ -108,16 +107,14 @@ def _opt_out(data, args):
         _error(data, args[0], "this command doesn't accept extra arguments")
         return
 
-    # See: https://redis.io/commands/get/
     key_prefix = "slack_opt_out:"
-    opt_out = store.get(key_prefix + data.user_id)
+    opt_out = redis.get(key_prefix + data.user_id)
     if opt_out:
         msg = ":no_bell: You're already opted out of PuRRR since: " + opt_out
         slack.chat_post_ephemeral(data.channel_id, data.user_id, msg)
         return
 
-    # See: https://redis.io/commands/set/
-    store.set(key_prefix + data.user_id, time.now())
+    redis.set(key_prefix + data.user_id, time.now())
     msg = ":no_bell: You are now opted out of PuRRR"
     slack.chat_post_ephemeral(data.channel_id, data.user_id, msg)
 

--- a/purrr/slack_helpers.star
+++ b/purrr/slack_helpers.star
@@ -1,5 +1,6 @@
 """Slack API helper functions."""
 
+load("@redis", "redis")
 load("@slack", "slack")
 load("debug.star", "debug")
 load("env", "SLACK_LOG_CHANNEL")  # Set in "autokitteh.yaml".
@@ -21,8 +22,7 @@ def add_users_to_channel(channel_id, users):
     # mentioned in the channel, but as non-members they won't know it.
     opted_in = []
     for user_id in users.split(","):
-        # See: https://redis.io/commands/get/
-        if not store.get("slack_opt_out:" + user_id):
+        if not redis.get("slack_opt_out:" + user_id):
             opted_in.append(user_id)
     users = ",".join(opted_in)
 
@@ -132,8 +132,7 @@ def lookup_pr_channel(pr_url, state, wait = False):
     """
     attempts = _CHANNEL_LOOKUP_TIMEOUT if wait else 1
     for _ in range(attempts):
-        # See: https://redis.io/commands/get/
-        channel_id = store.get(pr_url)
+        channel_id = redis.get(pr_url)
         if channel_id:
             return channel_id
         else:
@@ -158,8 +157,7 @@ def _lookup_review_message(review_url):
         Message's thread timestamp, or "" if not found.
     """
     for _ in range(_MESSAGE_LOOKUP_TIMEOUT):
-        # See: https://redis.io/commands/get/
-        thread_ts = store.get(review_url)
+        thread_ts = redis.get(review_url)
         if thread_ts:
             return thread_ts
         else:

--- a/purrr/user_helpers.star
+++ b/purrr/user_helpers.star
@@ -1,5 +1,6 @@
 """User-related helper functions across GitHub and Slack."""
 
+load("@redis", "redis")
 load("@github", "github")
 load("@slack", "slack")
 load("debug.star", "debug")
@@ -66,12 +67,10 @@ def github_username_to_slack_user_id(username):
     """
 
     # Optimization: if we already have it cached, return it.
-    # See: https://redis.io/commands/get/
-    slack_id = store.get("github_user:" + username)
+    slack_id = redis.get("github_user:" + username)
     if slack_id:
         # Optimization: extend the TTL after a successful cache hit.
-        # See: https://redis.io/commands/expire/
-        store.expire("github_user:" + username, _USER_CACHE_TTL)
+        redis.expire("github_user:" + username, _USER_CACHE_TTL)
         return slack_id
     if slack_id == "external user":
         # Note: don't extend the TTL for external-user cache hits,
@@ -89,8 +88,7 @@ def github_username_to_slack_user_id(username):
         slack_id = email_to_slack_user_id(resp.email)
         if slack_id:
             # Optimization: cache successful results for a day.
-            # See: https://redis.io/commands/set/
-            store.set("github_user:" + username, slack_id, _USER_CACHE_TTL)
+            redis.set("github_user:" + username, slack_id, _USER_CACHE_TTL)
             return slack_id
 
     # Otherwise, try to match by the user's full name.
@@ -103,14 +101,14 @@ def github_username_to_slack_user_id(username):
         )
         if gh_full_name in slack_names:
             # Optimization: cache successful results for a day.
-            store.set("github_user:" + username, user.id, _USER_CACHE_TTL)
+            redis.set("github_user:" + username, user.id, _USER_CACHE_TTL)
             return user.id
 
     link = "<https://github.com/%s|%s>" % ((username,) * 2)
     debug("GitHub user %s: email & name not found in Slack" % link)
 
     # Optimization: cache unsuccessful results too (i.e. external users).
-    store.set("github_user:" + username, "external user", _USER_CACHE_TTL)
+    redis.set("github_user:" + username, "external user", _USER_CACHE_TTL)
     return ""
 
 def resolve_github_user(github_user):


### PR DESCRIPTION
Motivation: don't prepend project and env IDs to keys in Redis, so the deployment won't care about where it's at, i.e. we won't need to mass-update Redis keys if we re-apply the project from scratch.