### PR TITLE
ENG-568: various updates in the PuRRR sample

### DIFF
--- a/purrr/README.md
+++ b/purrr/README.md
@@ -18,10 +18,10 @@ actual code!
 
 ## Slack Usage
 
-Slack private channels are created automatically for each PR, and stakeholders
-are added automatically to them. GitHub-to-Slack user matching is based on
-email addresses and case-insensitive full names. These channels are also
-un/archived automatically when the PR is closed/reopened.
+Slack channels are created automatically for each PR, and stakeholders are
+added automatically to them. GitHub-to-Slack user matching is based on email
+addresses and case-insensitive full names. These channels are also un/archived
+automatically when the PR is closed/reopened.
 
 Other channels that this system may use (if configured in the
 `autokitteh.yaml` manifest file):
@@ -46,7 +46,7 @@ This project uses [Redis](https://redis.io/) as a NoSQL cache for:
 3. Caching user IDs (optimization to reduce API calls)
 4. User opt-out database
 
-Use-cases 1 and 2 use a TTL of 100 days (configurable in the `autokitteh.yaml`
+Use-cases 1 and 2 use a TTL of 30 days (configurable in the `autokitteh.yaml`
 manifest file). Use-case 3 uses a TTL of one day since the last cache hit.
 Use-case 4 is permanent (until the user opts back in).
 

--- a/purrr/autokitteh.yaml
+++ b/purrr/autokitteh.yaml
@@ -1,8 +1,9 @@
 # Before applying this file:
-# - Modify the values in the "vars" section, if desired
-# - Create AutoKitteh connection tokens for GitHub and Slack,
-#   and replace the "TODO" lines below
+# - Modify the values in the project "vars" section, if desired
 # - Modify the Redis connection string, if needed
+#
+# After applying this file:
+# - Initialize the AutoKitteh connections to GitHub and Slack
 
 version: v1
 
@@ -21,13 +22,13 @@ project:
   connections:
     - name: github
       integration: github
-      token: TODO # Replace this with an AutoKitteh connection token.
     - name: redis
       integration: redis
-      token: "redis://localhost:6379/0" # Modify this if needed.
+      vars:
+        name: "URL"
+        value: "redis://localhost:6379/0" # Modify this if needed.
     - name: slack
       integration: slack
-      token: TODO # Replace this with an AutoKitteh connection token.
   triggers:
     - name: github_issue_comment
       connection: github

--- a/purrr/autokitteh.yaml
+++ b/purrr/autokitteh.yaml
@@ -13,6 +13,9 @@ project:
     # Default TTL for Redis cache = 30 days (to forget stale PRs).
     - name: REDIS_TTL
       value: 720h
+    # PR channel names: "pr_<number>_<title>".
+    - name: SLACK_CHANNEL_PREFIX
+      value: "pr_"
     # Create this channel / replace with your own / specify "" to disable it.
     - name: SLACK_DEBUG_CHANNEL
       value: purrr-debug
@@ -25,7 +28,7 @@ project:
     - name: redis
       integration: redis
       vars:
-        name: "URL"
+        name: URL
         value: "redis://localhost:6379/0" # Modify this if needed.
     - name: slack
       integration: slack

--- a/purrr/autokitteh.yaml
+++ b/purrr/autokitteh.yaml
@@ -28,8 +28,8 @@ project:
     - name: redis
       integration: redis
       vars:
-        name: URL
-        value: "redis://localhost:6379/0" # Modify this if needed.
+        - name: URL
+          value: "redis://localhost:6379/0" # Modify this if needed.
     - name: slack
       integration: slack
   triggers:

--- a/purrr/autokitteh.yaml
+++ b/purrr/autokitteh.yaml
@@ -13,7 +13,7 @@ project:
     # Default TTL for Redis cache = 30 days (to forget stale PRs).
     - name: REDIS_TTL
       value: 720h
-    # PR channel names: "pr_<number>_<title>".
+    # Default PR channel names: "pr_<number>_<title>".
     - name: SLACK_CHANNEL_PREFIX
       value: "pr_"
     # Create this channel / replace with your own / specify "" to disable it.
@@ -29,7 +29,7 @@ project:
       integration: redis
       vars:
         - name: URL
-          value: "redis://localhost:6379/0" # Modify this if needed.
+          value: redis://localhost:6379/0 # Modify this if needed.
     - name: slack
       integration: slack
   triggers:

--- a/purrr/github_pr.star
+++ b/purrr/github_pr.star
@@ -108,6 +108,7 @@ def _on_pr_opened(data):
     slack.bookmarks_add(channel_id, title, pr.htmlurl + ".diff")
 
     # Remember the ID of the channel we just created, for other events.
+    # See: https://redis.io/commands/set/
     resp = redis.set(pr.htmlurl, channel_id, REDIS_TTL)
     if resp != "OK":
         debug('Redis "set %s %s" failed: %s' % (pr.htmlurl, channel_id, resp))

--- a/purrr/github_pr.star
+++ b/purrr/github_pr.star
@@ -9,7 +9,7 @@ load(
     "slack_helpers.star",
     "add_users_to_channel",
     "archive_channel",
-    "create_private_channel",
+    "create_channel",
     "lookup_pr_channel",
     "mention_user_in_message",
     "normalize_channel_name",
@@ -76,9 +76,9 @@ def _on_pr_opened(data):
     """
     pr = data.pull_request
 
-    # Create a dedicated private Slack channel for the PR.
+    # Create a dedicated Slack channel for the PR.
     name = "%d_%s" % (pr.number, normalize_channel_name(pr.title))
-    channel_id = create_private_channel(data, name)
+    channel_id = create_channel(data, name)
     if not channel_id:
         user_id = github_username_to_slack_user_id(data.sender.login)
         msg = "Failed to create a Slack channel for %s" % pr.htmlurl

--- a/purrr/github_pr_review.star
+++ b/purrr/github_pr_review.star
@@ -46,6 +46,7 @@ def _on_pr_review_submitted(data):
 
     # Remember the thread timestamp (message ID) of the message we posted.
     if thread_ts:
+        # See: https://redis.io/commands/set/
         resp = redis.set(data.review.htmlurl, thread_ts, REDIS_TTL)
         if resp != "OK":
             msg = 'Redis "set %s %s" failed: %s'

--- a/purrr/slack_cmd.star
+++ b/purrr/slack_cmd.star
@@ -85,6 +85,7 @@ def _opt_in(data, args):
         _error(data, args[0], "this command doesn't accept extra arguments")
         return
 
+    # See: https://redis.io/commands/get/
     key_prefix = "slack_opt_out:"
     opt_out = redis.get(key_prefix + data.user_id)
     if not opt_out:
@@ -92,6 +93,7 @@ def _opt_in(data, args):
         slack.chat_post_ephemeral(data.channel_id, data.user_id, msg)
         return
 
+    # See: https://redis.io/commands/del/
     redis.delete(key_prefix + data.user_id)
     msg = ":bell: You are now opted into PuRRR"
     slack.chat_post_ephemeral(data.channel_id, data.user_id, msg)
@@ -107,6 +109,7 @@ def _opt_out(data, args):
         _error(data, args[0], "this command doesn't accept extra arguments")
         return
 
+    # See: https://redis.io/commands/get/
     key_prefix = "slack_opt_out:"
     opt_out = redis.get(key_prefix + data.user_id)
     if opt_out:
@@ -114,6 +117,7 @@ def _opt_out(data, args):
         slack.chat_post_ephemeral(data.channel_id, data.user_id, msg)
         return
 
+    # See: https://redis.io/commands/set/
     redis.set(key_prefix + data.user_id, time.now())
     msg = ":no_bell: You are now opted out of PuRRR"
     slack.chat_post_ephemeral(data.channel_id, data.user_id, msg)

--- a/purrr/slack_helpers.star
+++ b/purrr/slack_helpers.star
@@ -3,7 +3,7 @@
 load("@redis", "redis")
 load("@slack", "slack")
 load("debug.star", "debug")
-load("env", "SLACK_LOG_CHANNEL")  # Set in "autokitteh.yaml".
+load("env", "SLACK_CHANNEL_PREFIX", "SLACK_LOG_CHANNEL")  # Set in "autokitteh.yaml".
 load("user_helpers.star", "resolve_github_user")
 
 _CHANNEL_MAX_METADATA_LENGTH = 250  # Characters.
@@ -97,7 +97,7 @@ def create_channel(data, name, suffix = 1):
 
     # Create the channel.
     # See: https://api.slack.com/methods/conversations.create
-    resp = slack.conversations_create("pr_" + n)
+    resp = slack.conversations_create(SLACK_CHANNEL_PREFIX + n)
     if not resp.ok:
         if resp.error == "name_taken":
             # If a channel with the same name already exists,
@@ -246,7 +246,7 @@ def rename_channel(channel_id, name, suffix = 1):
 
     # Rename the channel.
     # See: https://api.slack.com/methods/conversations.rename
-    resp = slack.conversations_rename(channel_id, "pr_" + n)
+    resp = slack.conversations_rename(channel_id, SLACK_CHANNEL_PREFIX + n)
     if not resp.ok:
         if resp.error == "name_taken":
             # If a channel with the same name already exists,

--- a/purrr/slack_helpers.star
+++ b/purrr/slack_helpers.star
@@ -22,6 +22,7 @@ def add_users_to_channel(channel_id, users):
     # mentioned in the channel, but as non-members they won't know it.
     opted_in = []
     for user_id in users.split(","):
+        # See: https://redis.io/commands/get/
         if not redis.get("slack_opt_out:" + user_id):
             opted_in.append(user_id)
     users = ",".join(opted_in)
@@ -76,8 +77,8 @@ def archive_channel(channel_id, data):
 
     return resp.ok
 
-def create_private_channel(data, name, suffix = 1):
-    """Create a private Slack channel.
+def create_channel(data, name, suffix = 1):
+    """Create a public Slack channel.
 
     Args:
         data: GitHub event data.
@@ -96,14 +97,14 @@ def create_private_channel(data, name, suffix = 1):
 
     # Create the channel.
     # See: https://api.slack.com/methods/conversations.create
-    resp = slack.conversations_create(n, is_private = True)
+    resp = slack.conversations_create("pr_" + n)
     if not resp.ok:
         if resp.error == "name_taken":
             # If a channel with the same name already exists,
             # try again recursively with a numeric suffix.
-            return create_private_channel(data, name, suffix + 1)
+            return create_channel(data, name, suffix + 1)
         else:
-            debug('Create private Slack channel "%s": `%s`' % (n, resp.error))
+            debug('Create Slack channel "%s": `%s`' % (n, resp.error))
             return ""
 
     # As long as the channel was created, these nice-to-haves aren't critical.
@@ -132,6 +133,7 @@ def lookup_pr_channel(pr_url, state, wait = False):
     """
     attempts = _CHANNEL_LOOKUP_TIMEOUT if wait else 1
     for _ in range(attempts):
+        # See: https://redis.io/commands/get/
         channel_id = redis.get(pr_url)
         if channel_id:
             return channel_id
@@ -157,6 +159,7 @@ def _lookup_review_message(review_url):
         Message's thread timestamp, or "" if not found.
     """
     for _ in range(_MESSAGE_LOOKUP_TIMEOUT):
+        # See: https://redis.io/commands/get/
         thread_ts = redis.get(review_url)
         if thread_ts:
             return thread_ts
@@ -243,7 +246,7 @@ def rename_channel(channel_id, name, suffix = 1):
 
     # Rename the channel.
     # See: https://api.slack.com/methods/conversations.rename
-    resp = slack.conversations_rename(channel_id, n)
+    resp = slack.conversations_rename(channel_id, "pr_" + n)
     if not resp.ok:
         if resp.error == "name_taken":
             # If a channel with the same name already exists,

--- a/purrr/user_helpers.star
+++ b/purrr/user_helpers.star
@@ -1,7 +1,7 @@
 """User-related helper functions across GitHub and Slack."""
 
-load("@redis", "redis")
 load("@github", "github")
+load("@redis", "redis")
 load("@slack", "slack")
 load("debug.star", "debug")
 
@@ -67,9 +67,11 @@ def github_username_to_slack_user_id(username):
     """
 
     # Optimization: if we already have it cached, return it.
+    # See: https://redis.io/commands/get/
     slack_id = redis.get("github_user:" + username)
     if slack_id:
         # Optimization: extend the TTL after a successful cache hit.
+        # See: https://redis.io/commands/expire/
         redis.expire("github_user:" + username, _USER_CACHE_TTL)
         return slack_id
     if slack_id == "external user":
@@ -88,6 +90,7 @@ def github_username_to_slack_user_id(username):
         slack_id = email_to_slack_user_id(resp.email)
         if slack_id:
             # Optimization: cache successful results for a day.
+            # See: https://redis.io/commands/set/
             redis.set("github_user:" + username, slack_id, _USER_CACHE_TTL)
             return slack_id
 
@@ -101,6 +104,7 @@ def github_username_to_slack_user_id(username):
         )
         if gh_full_name in slack_names:
             # Optimization: cache successful results for a day.
+            # See: https://redis.io/commands/set/
             redis.set("github_user:" + username, user.id, _USER_CACHE_TTL)
             return user.id
 
@@ -108,6 +112,7 @@ def github_username_to_slack_user_id(username):
     debug("GitHub user %s: email & name not found in Slack" % link)
 
     # Optimization: cache unsuccessful results too (i.e. external users).
+    # See: https://redis.io/commands/set/
     redis.set("github_user:" + username, "external user", _USER_CACHE_TTL)
     return ""
 


### PR DESCRIPTION
- Update the manifest to be compatible with AK v0.5.1
- Use public Slack channels instead of private ones
- Support a configurable Slack channel prefix, "pr_" by default
- Add Redis comments back into the code as a reference