### PR TITLE
ENG-838: Resolve Slack IDs to GitHub full names

### DIFF
--- a/purrr/markdown.star
+++ b/purrr/markdown.star
@@ -1,6 +1,6 @@
 """Markdown-related helper functions across GitHub and Slack."""
 
-load("user_helpers.star", "resolve_github_user")
+load("user_helpers.star", "resolve_github_user", "resolve_slack_user")
 
 def github_markdown_to_slack(text, pr_url, github_owner = ""):
     """Convert GitHub markdown text to Slack markdown text.
@@ -8,7 +8,7 @@ def github_markdown_to_slack(text, pr_url, github_owner = ""):
     References:
     - https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
     - https://api.slack.com/reference/surfaces/formatting
-    - https://qri.io/docs/reference/starlark-packages/re
+    - https://github.com/qri-io/starlib/tree/master/re
 
     Args:
         text: Text body, possibly containing GitHub markdown.
@@ -60,16 +60,17 @@ def github_markdown_to_slack(text, pr_url, github_owner = ""):
 
     return text
 
-def slack_markdown_to_github(text):
+def slack_markdown_to_github(text, github_owner = ""):
     """Convert Slack markdown text to GitHub markdown text.
 
     References:
     - https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
     - https://api.slack.com/reference/surfaces/formatting
-    - https://qri.io/docs/reference/starlark-packages/re
+    - https://github.com/qri-io/starlib/tree/master/re
 
     Args:
         text: Text body, possibly containing Slack markdown.
+        github_owner: Optional, for GitHub org-specific visibility.
 
     Returns:
         GitHub markdown text.
@@ -86,7 +87,10 @@ def slack_markdown_to_github(text):
     # (see https://api.slack.com/reference/deep-linking).
     text = re.sub(r"\[(.*?)\]\(#(.*?)\)", "[#$1](https://slack.com/app_redirect?channel=$2)", text)
 
-    # TODO: Users: "<@U...>" --> "@github-user".
+    # Users: "<@U...>" --> "@github-user".
+    for slack_user in re.findall(r"<@[UW][0-9A-Z]*?>", text):
+        github_user = resolve_slack_user(slack_user[2:-1], github_owner)
+        text = text.replace(slack_user, github_user)
 
     # TODO: Multiline code blocks: ```aaa\nbbb``` --> ```\naaa\nbbb\n```
 

--- a/purrr/slack_message.star
+++ b/purrr/slack_message.star
@@ -28,18 +28,19 @@ def _on_slack_new_message(data):
     Args:
         data: Slack event data.
     """
-    github_user = resolve_slack_user(data.user)
 
     # See: https://redis.io/commands/get/
     owner, repo, pr = redis.get(data.channel).split(":")
     pr = int(pr)
+
+    github_user = resolve_slack_user(data.user, owner)
 
     # See subtype bug note in https://api.slack.com/events/message/message_replied
     if not data.thread_ts:
         # Slack message = GitHub review + single comment (we only need the comment
         # for correct 2-way syncs, but we can't have it without a parent review).
         review = "%s via %s" % (github_user, get_permalink(data.channel, data.ts))
-        comment = slack_markdown_to_github(data.text)
+        comment = slack_markdown_to_github(data.text, owner)
         create_review_comment(owner, repo, pr, review, comment, data.channel, data.ts)
     else:
         # Slack threaded reply = GitHub review comment.
@@ -49,7 +50,7 @@ def _on_slack_new_message(data):
         else:
             # Special case but same result: reply is broadcasted to the channel.
             body %= (github_user, get_permalink(data.channel, data.root.ts))
-        body += slack_markdown_to_github(data.text)
+        body += slack_markdown_to_github(data.text, owner)
 
         create_review_comment_reply(owner, repo, pr, body, data.channel, data.thread_ts)
 

--- a/purrr/slack_reaction.star
+++ b/purrr/slack_reaction.star
@@ -1,5 +1,6 @@
 """Handler for Slack reaction events."""
 
+load("@redis", "redis")
 load("@slack", "slack")
 load("user_helpers.star", "resolve_slack_user")
 
@@ -9,7 +10,8 @@ def on_slack_reaction_added(data):
     Args:
         data: Slack event data.
     """
-    github_user = resolve_slack_user(data.user)
+    owner, _, _ = redis.get(data.item.channel).split(":")
+    github_user = resolve_slack_user(data.user, owner)
     msg = ":point_up: TODO - add GitHub review comment: `%s` added reaction `%s` (channel = `%s`, TS = `%s`)"
     msg %= (github_user, data.reaction, data.item.channel, data.item.ts)
     slack.chat_post_message(data.channel, msg)

--- a/purrr/user_helpers.star
+++ b/purrr/user_helpers.star
@@ -164,11 +164,12 @@ def resolve_github_user(github_user, owner_org = ""):
         # Otherwise, fall-back to their GitHub profile link.
         return "<%s|%s>" % (github_user.htmlurl, github_user.login)
 
-def resolve_slack_user(slack_user_id):
+def resolve_slack_user(slack_user_id, github_owner = ""):
     """Convert a Slack user ID to a GitHub user reference.
 
     Args:
         slack_user_id: Slack user ID.
+        github_owner: Optional, for GitHub org-specific visibility.
 
     Returns:
         GitHub user reference, or the Slack user's full name, or "Someone".


### PR DESCRIPTION
This is the first step to resolve ENG-838 - the next is to search for GitHub accounts (requires an addition to the GitHub integration in AK), and 2 more markdown TODOs.